### PR TITLE
Channge variable to db_password

### DIFF
--- a/src/dags/request_news.py
+++ b/src/dags/request_news.py
@@ -24,7 +24,7 @@ from utils.sqlconnector import SQLConnector
 def yfinance_dag():
     
     db_user = Variable.get('db_user')
-    db_pwd = Variable.get('db_pwd')
+    db_pwd = Variable.get('db_password')
     number_of_news = int(Variable.get('number_news', default_var=5))
                          
     connector = SQLConnector(username=db_user, password=db_pwd)


### PR DESCRIPTION
In order to store the password as a hidden key, variable naming convenntion has been changed to include the word password.