### PR TITLE
Cambios a query obtener datos a computar indicadores

### DIFF
--- a/src/dags/obtain_stock_data.py
+++ b/src/dags/obtain_stock_data.py
@@ -205,7 +205,7 @@ def stock_data_dag():
             WHERE ticker_id = {ticker_id}
                 AND (rsi IS NULL OR aroon_up IS NULL OR macd IS NULL OR obv IS NULL)
                 AND value_at >= (
-                    SELECT DATE_SUB(MAX(value_at), INTERVAL {data_depth} MONTH)
+                    SELECT DATE_SUB(MAX(value_at), INTERVAL {data_depth}+1 MONTH)
                     FROM stock_data_daily
                     WHERE ticker_id = {ticker_id}
                 )


### PR DESCRIPTION
Debido a que el modelo siempre utilizara una profundidad determinada, se utiliza esta profundidad para obtener los datos sobre los cuales se debenn obtener los indicadores. A la profundidad se le anade 1  mes ya que es un valor seguro para que todos los indicadores esten calculados