### PR TITLE
Reorganizacion importaciones y set de variable de entornno antes de i…

### DIFF
--- a/src/dags/train_model.py
+++ b/src/dags/train_model.py
@@ -93,14 +93,12 @@ def train_model_dag():
         """
     )
     def generate_models(ticker_dict):
+        import os
+        os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2' # Eliminacion logging INFO y WARNING keras
         import keras
         from sklearn.preprocessing import MinMaxScaler
-        import tensorflow as tf
         import numpy as np
         import warnings
-        import os
-        
-        os.environ['TF_CPP_MIN_LOG_LEVEL'] = '1' # Eliminacion logging INFO keras
         
         warnings.filterwarnings('ignore')
         


### PR DESCRIPTION
…mportar keras

La variable de entorno se debe definir antes de la importacion de keras. 
Se aprovecha para tambien eliminar los warnings, aunque actualmente no se recibio ningunno.