### PR TITLE
Cambio a load_model

### DIFF
--- a/src/dags/train_model.py
+++ b/src/dags/train_model.py
@@ -307,7 +307,7 @@ def train_model_dag():
 
                     
                     # Carga mejor modelo
-                    keras.models.load_model(model_file_path)
+                    model:keras.Sequential = keras.models.load_model(model_file_path)
                     X_test = np.load(X_file_path)
                     y_test = np.load(y_file_path)
                     


### PR DESCRIPTION
La funcion load_weights solamente se puede utilizar si un modelo ya esta instanciado. Debido que ene ste caso enn cocnreto se almacenann para luego leerlos y hacer el plot, se debe cargar el modelo de nuevo con toda su arquitectura y pesos.