### PR TITLE
prev_date

### DIFF
--- a/src/dags/request_av_news.py
+++ b/src/dags/request_av_news.py
@@ -135,7 +135,7 @@ def alpha_vantage_dag():
                                 
                             if prev_date==max_date:
                                 logging.info('Aun no se recibieron las noticias del dia')
-                                break
+                                overflow=True
                             
                                 
                 if len(news_list)>1000:


### PR DESCRIPTION
Es posible que no se encuentren fechas actualizadas el dia de ejecucion. En tal caso que se produzca break.